### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -122,6 +122,11 @@
                             if (typeof elem === 'string') {
                               elem = $.trim(elem);
                             }
+
+                            if (!value) {
+                              return;
+                            }
+
                             data.entries.push(elem);
                             if ( data.columns.indexOf(elem) === -1 ) {
                               data.columns.push(elem);
@@ -135,6 +140,11 @@
                           if (typeof value === 'string') {
                             value = $.trim(value);
                           }
+
+                          if (!value) {
+                            return;
+                          }
+
                           data.entries.push(value);
                           if ( data.columns.indexOf(value) === -1 ) {
                             data.columns.push(value);


### PR DESCRIPTION
@tonytlwu @squallstar

## Issue
Fliplet/fliplet-studio#4879

## Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data.

## Screenshots/screencasts
Before:
<img width="343" alt="Column demo 2" src="https://user-images.githubusercontent.com/52824207/64524892-41e16380-d308-11e9-86a3-4b78dd070b20.png">
After:
<img width="343" alt="Column demo 1" src="https://user-images.githubusercontent.com/52824207/64524893-41e16380-d308-11e9-9474-d0773a927a3a.png">

## Backward compatibility
This change is fully backward compatible.