### PR TITLE
Columns with empty names will be ignored when summarizing data

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
 
   <header>
     <p>Configure your column chart</p>
-    <a href="#">Need help?</a>
+    <a href="https://help.fliplet.com/article/62-how-to-configure-charts" target="_blank">Need help?</a>
   </header>
 
   <div class="form-horizontal">

--- a/js/build.js
+++ b/js/build.js
@@ -122,6 +122,11 @@
                             if (typeof elem === 'string') {
                               elem = $.trim(elem);
                             }
+
+                            if (!elem) {
+                              return;
+                            }
+
                             data.entries.push(elem);
                             if ( data.columns.indexOf(elem) === -1 ) {
                               data.columns.push(elem);
@@ -135,6 +140,11 @@
                           if (typeof value === 'string') {
                             value = $.trim(value);
                           }
+
+                          if (!value) {
+                            return;
+                          }
+
                           data.entries.push(value);
                           if ( data.columns.indexOf(value) === -1 ) {
                             data.columns.push(value);

--- a/js/interface.js
+++ b/js/interface.js
@@ -86,7 +86,6 @@ var dsQueryProvider = Fliplet.Widget.open('com.fliplet.data-source-query', {
 
 // Ensure chart heights have a correct default & units
 function validateChartHeight(val, size) {
-  debugger;
   if (typeof val !== 'string') {
     val = val.toString() || '';
   }


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4879
Fliplet/fliplet-studio#4911

Description
If the column has empty or a name that contains only spaces it will be ignored when summarizing data. Added need help link.

Backward compatibility
This change is fully backward compatible.