### PR TITLE
Changing the sort order is saved after saving

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -117,4 +117,7 @@ if (data) {
   if (data.dataSourceQuery && data.dataSourceQuery.selectedModeIdx === 1) {
     $('.column-sort-order').removeClass('hidden');
   }
+  if (data.dataSortOrder) {
+    $('#select-data-sort-order').val(data.dataSortOrder);
+  }
 }


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#5264

## Description
If the user saved sorting order it will be restored after the component is loaded.

## Screenshots/screencasts
![chart save demo ](https://user-images.githubusercontent.com/52824207/68998974-0643b680-08c2-11ea-8acb-aaf0955a252d.gif)

## Backward compatibility
This change is fully backward compatible.