### PR TITLE
ID-458 [Feat] Adds chart name and support for refreshing via JS API

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -100,6 +100,14 @@
         </div>
       </div>
     </div>
+    <div class="form-group">
+      <div class="col-sm-4 control-label">
+        <label for="chart_name">Chart name (for JS API)</label> <a href="https://developers.fliplet.com/API/components/charts.html">Learn more</a>
+      </div>
+      <div class="col-sm-8">
+        <input type="text" class="form-control" id="chart_name" name="chart_name" placeholder="(Optional)" value="">
+      </div>
+    </div>
 
   </div>
 

--- a/js/build.js
+++ b/js/build.js
@@ -11,6 +11,7 @@
       var chartUuid = data.uuid;
       var $container = $(this);
       var refreshTimeout = 5000;
+      var refreshTimer;
       var updateDateFormat = 'hh:mm:ss a';
       var colors = [
         '#00abd1', '#ed9119', '#7D4B79', '#F05865', '#36344C',
@@ -226,25 +227,34 @@
         refreshChartInfo();
       }
 
-      function getLatestData() {
-        return new Promise(function (resolve, reject) {
-          setTimeout(function () {
-            refreshData().then(function () {
-              if (data.autoRefresh) {
-                getLatestData();
-              }
+      function refresh() {
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+          refreshTimer = null;
+        }
 
-              refreshChart();
-              resolve();
-            }).catch(function (err) {
-              if (data.autoRefresh) {
-                getLatestData();
-              }
+        return refreshData().then(function () {
+          if (data.autoRefresh) {
+            setRefreshTimer();
+          }
 
-              reject(err);
-            });
-          }, refreshTimeout);
+          return refreshChart();
+        }).catch(function (err) {
+          if (data.autoRefresh) {
+            setRefreshTimer();
+          }
+
+          return Promise.reject(err);
         });
+      }
+
+      function setRefreshTimer() {
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+          refreshTimer = null;
+        }
+
+        setTimeout(refresh, refreshTimeout);
       }
 
       Fliplet.Studio.onEvent(function(event) {
@@ -294,7 +304,7 @@
                 load: function () {
                   refreshChartInfo();
                   if (data.autoRefresh) {
-                    getLatestData();
+                    setRefreshTimer();
                   }
                 },
                 render: function () {
@@ -430,7 +440,7 @@
 
       refreshData().then(drawChart).catch(function (error) {
         console.error(error);
-        getLatestData();
+        setRefreshTimer();
       });
 
       Fliplet.Chart.add(chartPromise);
@@ -438,7 +448,7 @@
       chartReady({
         name: data.chartName,
         type: 'column',
-        refresh: getLatestData
+        refresh: refresh
       });
     });
   }

--- a/js/build.js
+++ b/js/build.js
@@ -3,6 +3,8 @@
   window.ui = window.ui || {}
   ui.flipletCharts = ui.flipletCharts || {};
 
+  Fliplet.Chart = Fliplet.Widget.Namespace('chart');
+
   function init() {
     Fliplet.Widget.instance('chart-column', function (data) {
       var chartId = data.id;
@@ -15,6 +17,11 @@
         '#474975', '#8D8EA6', '#FF5722', '#009688', '#E91E63'
       ];
       var chartInstance;
+
+      var chartReady;
+      var chartPromise = new Promise(function(resolve) {
+        chartReady = resolve;
+      });
 
       function resetData() {
         data.entries = [];
@@ -270,7 +277,7 @@
             var newColor = customColors
               ? customColors.values[colorKey]
               : Fliplet.Themes.Current.get(colorKey);
-            
+
             if (newColor) {
               colors[index] = newColor;
             }
@@ -424,6 +431,13 @@
       refreshData().then(drawChart).catch(function (error) {
         console.error(error);
         getLatestData();
+      });
+
+      Fliplet.Chart.add(chartPromise);
+
+      chartReady({
+        name: data.chartName,
+        refresh: getLatestData
       });
     });
   }

--- a/js/build.js
+++ b/js/build.js
@@ -254,7 +254,7 @@
           refreshTimer = null;
         }
 
-        setTimeout(refresh, refreshTimeout);
+        refreshTimer = setTimeout(refresh, refreshTimeout);
       }
 
       Fliplet.Studio.onEvent(function(event) {

--- a/js/build.js
+++ b/js/build.js
@@ -437,6 +437,7 @@
 
       chartReady({
         name: data.chartName,
+        type: 'column',
         refresh: getLatestData
       });
     });

--- a/js/build.js
+++ b/js/build.js
@@ -251,7 +251,6 @@
       function setRefreshTimer() {
         if (refreshTimer) {
           clearTimeout(refreshTimer);
-          refreshTimer = null;
         }
 
         refreshTimer = setTimeout(refresh, refreshTimeout);

--- a/js/interface.js
+++ b/js/interface.js
@@ -125,7 +125,7 @@ function validateForm() {
 function attachObservers() {
   dsQueryProvider.then(function(result){
     validateForm();
-    
+
     Fliplet.Widget.save({
       // dataSourceId: parseInt($dataSource.val(), 10),
       // dataSourceColumn: $dataColumns.val(),
@@ -135,6 +135,7 @@ function attachObservers() {
       chartHeightMd: $('#chart_height_md').val(),
       showDataLegend: $('#show_data_legend').is(':checked'),
       showDataValues: $('#show_data_values').is(':checked'),
+      chartName: $('#chart_name').val(),
       yAxisTitle: $('#y_axis_title').val(),
       xAxisTitle: $('#x_axis_title').val(),
       showTotalEntries: $('#show_total_entries').is(':checked'),
@@ -159,6 +160,7 @@ if (data) {
   $('#chart_height_md').val(data.chartHeightMd);
   $('#show_data_legend').prop('checked', data.showDataLegend);
   $('#show_data_values').prop('checked', data.showDataValues);
+  $('#chart_name').val(data.chartName);
   $('#y_axis_title').val(data.yAxisTitle);
   $('#x_axis_title').val(data.xAxisTitle);
   $('#show_total_entries').prop('checked', data.showTotalEntries);


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-458

Requires https://github.com/Fliplet/fliplet-api/pull/4384

Adds support for:

```js
Fliplet.Chart.get('My chart').then(function(chart) {
  // Refresh chart
  chart.refresh();
});
```

![image](https://user-images.githubusercontent.com/290733/99992204-efc21c00-2dad-11eb-9260-fa279ca5dde9.png)
